### PR TITLE
Fix/less logging

### DIFF
--- a/app/partitions.go
+++ b/app/partitions.go
@@ -91,7 +91,6 @@ func (part *Partitions) getPartitionPosition(cfg *Config, queueName string) (int
 	} else {
 		return myPartition, totalPartitions, errors.New("no available partitions")
 	}
-	//log.Println("partition: " + strconv.Itoa(workingPartition.Id) + " occupied time: " + strconv.FormatFloat(time.Since(workingPartition.LastUsed).Seconds(), 'f', -1, 64))
 	visTimeout, _ := cfg.GetVisibilityTimeout(queueName)
 	if time.Since(workingPartition.LastUsed).Seconds() > visTimeout {
 		myPartition = workingPartition.Id
@@ -140,7 +139,6 @@ func (part *Partitions) syncPartitions(cfg *Config, queueName string) {
 		_, _ = part.partitions.Pop()
 		totalPartitions = totalPartitions - 1
 	}
-	log.Println("removed " + strconv.Itoa(partsRemoved) + "partitions from queue " + queueName)
 
 	if part.partitions.Size() < minPartitions {
 		part.makePartitions(cfg, queueName, minPartitions-totalPartitions)

--- a/app/queue.go
+++ b/app/queue.go
@@ -177,7 +177,6 @@ func (queue *Queue) Delete(cfg *Config, id string) bool {
 	defer cfg.ReleaseRiakConnection(client)
 	bucket, err := client.NewBucket(queue.Name)
 	if err == nil {
-		log.Println("Deleting: ", id)
 		err = bucket.Delete(id)
 		if err == nil {
 			defer decrementMessageCount(cfg.Stats.Client, queue.Name, 1)


### PR DESCRIPTION
removing a bunch of extraneous log statements that I don't believe are in use.

Additionally I noticed that we have two methods of logging Errors

1) log.Println(err)
2) log.Printf("Error%v", err)

I personnaly don't have a preference on the two, but anyone have thoughts? @wjossey @StabbyCutyou @mattcarbone 
