### PR TITLE
Dont' fail if build directory already exists

### DIFF
--- a/deploy/build
+++ b/deploy/build
@@ -3,10 +3,10 @@
 set -x
 set -e
 
-mkdir build
+mkdir -p build
 cd build
 export GOPATH=`pwd`
 go get github.com/Tapjoy/dynamiq
 cd ..
 cp build/bin/dynamiq ./dynamiq
-rm -rf build app dynamiq.go README.md 
+rm -rf build app dynamiq.go README.md


### PR DESCRIPTION
@StabbyCutyou @lumost 
This may not be the only change to the repo needed to get this to work. The build is currently failing with 

```
+ export GOPATH=/mnt/jenkins/workspace/slug-builder/dynamiq/build
+ GOPATH=/mnt/jenkins/workspace/slug-builder/dynamiq/build
+ go get github.com/Tapjoy/dynamiq
src/code.google.com/p/goprotobuf/proto/text.go:39:2: no Go source files in /usr/lib/go/src/pkg/encoding
         run  Command result pid 7866 exit 1. Command output: 
```
