### PR TITLE
adding some fixes for handling chore throughput

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-dynamiq: ./dynamiq 
+dynamiq: export GOMAXPROCS=4; ./dynamiq 

--- a/lib/config.gcfg
+++ b/lib/config.gcfg
@@ -5,8 +5,8 @@
  seedport=7000
  httpport=8081
  riaknodes="127.0.0.1:8087"
- backendconnectionpool=16
- syncconfiginterval=10000
+ backendconnectionpool=128
+ syncconfiginterval=1000
 [stats]
  type=statsd #(statsd|statsdinternal|none)
  flushinterval=2 #number of seconds to hold data in memory before flushing


### PR DESCRIPTION
@Tapjoy/dynamiq 

@StabbyCutyou and I spent the morning going over some tapinaboxes that were borked, and noticed two things
1. in the sync partitions code there was no protection against an empty partition queue ( which could happen now that we pass the partition struct through to the Get call ) ( fixed in stabby's branch )
2. with more than 1024 concurrent non-keepalived connections we could saturate go ( hence the export of GOMAXPROCS=4)
3. with over 50 concurrent chore requests to a queue a riak connection pool of 16 is too small 
4. there was a potential for deadlocking between the call to pull a partition from the PQ to the call to get a riak connection ( we believe this is the cause of dead tapinaboxes )

this branch in combination with Stabby's is keeping dynamiq happy at 1024+ concurrent connections as tested by ab
