### PR TITLE
Fixing issue where we were returning duplicate partitions we had already...

### DIFF
--- a/app/partitions.go
+++ b/app/partitions.go
@@ -42,7 +42,6 @@ func (part *Partitions) PartitionCount() int {
 	return part.partitionCount
 }
 func (part *Partitions) GetPartition(cfg *Config, queueName string, list *memberlist.Memberlist) (int, int, *Partition, error) {
-
 	//get the node position and the node count
 	nodePosition, nodeCount := getNodePosition(list)
 
@@ -102,16 +101,16 @@ func (part *Partitions) getPartitionPosition(cfg *Config, queueName string) (int
 	} else {
 		part.partitions.Push(workingPartition, workingPartition.LastUsed.UnixNano())
 		part.Lock()
+		defer part.Unlock()
 		maxPartitions, _ := cfg.GetMaxPartitions(queueName)
 		if part.partitionCount < maxPartitions {
-			workingPartition := new(Partition)
+			workingPartition = new(Partition)
 			workingPartition.Id = part.partitionCount
 			myPartition = workingPartition.Id
 			part.partitionCount = part.partitionCount + 1
 		} else {
 			err = errors.New(NOPARTITIONS)
 		}
-		part.Unlock()
 	}
 	return myPartition, workingPartition, part.partitionCount, err
 }


### PR DESCRIPTION
... pushed onto the queue further up the chain

ping @lumost @theo-lanman 

Where the hell do I even begin

I was reading the logs on Friday while James and I were debugging some issues with the deployment of Dynamiq. I noticed that in local testing, I was always ending up with messages stuck in my queue - A reboot of Dynamiq was needed to clear them. Additionally, I noticed that I wasn't seeing the entries I would have imagined for the partition top and bottom - namely, I was never seeing the extreme upper bound of the keyspace for the node.

After playing around a bit, I learned the following:

As soon as we hit a condition that requires partitions to grow, we would encounter the "lost messages" issue.
We correctly create 1 instance of each Partition with the correct ID
Through some mechanic, the Queue holding Partitions was winding up with several duplicates.
These duplicates were only ever among the set limited by the MinPartition value
In other words, if MinPartitions was 30, the partitions queue would end up in a state where it had some subset of the numbers 0 to 29, with many repeats.
If I commented out the code which results in no locking occuring for Partitions in which we searched but found no messages, the problem went away
In other words, if we lock partitions by default every time, the problem went away
Through logging, I pinpointed the likely place where duplicate partitions were being created was the code block I've pushed up here in my PR
By adding this early-return statement and defer-ing the unlock, we experience no duplication and correct partition growth.

This lead me to an experiment, and the experiment showed what was really happening

``` go
workingPartition := new(Partition)
```

IS NOT THE SAME GODDAMN THING AS 

``` go
workingPartition = new(Partition)
```

BOOM, ROASTED

:= creates a new local scope variable, covering the higher scope variable, and allocates empty memory in the shape of the struct in new()
= allocates empty memory in the shape of the struct in new()

DROP MIC I AM FUCKING OUT HAPPY BIRTHDAY TO ME ASSHOLES
