### PR TITLE
Fixing logger in HTTP context not respecting log levels

### DIFF
--- a/app/httpinterface_v1.go
+++ b/app/httpinterface_v1.go
@@ -48,11 +48,14 @@ func logrusLogger() martini.Handler {
 	}
 }
 
-func dynamiqMartini() *martini.ClassicMartini {
+func dynamiqMartini(cfg *Config) *martini.ClassicMartini {
 	r := martini.NewRouter()
 	m := martini.New()
 
-	m.Map(logrus.New())
+	log := logrus.New()
+	log.Level = cfg.Core.LogLevel
+
+	m.Map(log)
 	m.Use(logrusLogger())
 	m.Use(martini.Recovery())
 	m.Use(martini.Static("public"))
@@ -70,7 +73,7 @@ func (h HTTP_API_V1) InitWebserver(list *memberlist.Memberlist, cfg *Config) {
 	queues := cfg.Queues
 	// also tieing topics this is next for refactor
 	topics := InitTopics(cfg, queues)
-	m := dynamiqMartini()
+	m := dynamiqMartini(cfg)
 	m.Use(render.Renderer())
 
 	// Group the routes underneath their version


### PR DESCRIPTION
ping @lumost @alvindu 

This fixes it so the HTTP logger respects the application level logging - currently it does not
