### PR TITLE
Enabling Procfile to run with a variable config location

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-dynamiq: export GOMAXPROCS=4; ./dynamiq 
+dynamiq: export GOMAXPROCS=4; ./dynamiq -c "$DYNAMIQ_CONFIG_PATH"

--- a/dynamiq.go
+++ b/dynamiq.go
@@ -11,6 +11,11 @@ func main() {
 	config_file := flag.String("c", "./lib/config.gcfg", "location of config file")
 	flag.Parse()
 
+	if *config_file == "" {
+		logrus.Warn("Empty value provided for config file location from flag -c : Falling back to default location './lib/config.gcfg'")
+		*config_file = "./lib/config.gcfg"
+	}
+
 	//setup the config file
 	cfg, err := app.GetCoreConfig(config_file)
 


### PR DESCRIPTION
ping @lumost @geoffreyclark 

Thoughts?

Not sure about the "extra protection" against an empty -c "" flag, but my thought was someone could use the Procfile locally without setting / needing to set the env var
