### PR TITLE
Fixing too-aggressive sync poll interval by default.

### DIFF
--- a/lib/config.gcfg
+++ b/lib/config.gcfg
@@ -6,7 +6,7 @@
  httpport=8081
  riaknodes="127.0.0.1:8087"
  backendconnectionpool=128
- syncconfiginterval=1000
+ syncconfiginterval=30000 # 30 seconds by default
  loglevelstring=debug # understandable by logrus.ParseLevel
 [stats]
  type=statsd #(statsd|none)


### PR DESCRIPTION
ping @lumost 

Would you believe that polling the CRDTs as we do once per second is somehow eating up a lot riak CPU in TIAB?

I wouldn't have.

But if you drop the polling time, Riaks "idle" cpu goes from 25~45% to 5%.

I'm gonna try and dig into why that's so harsh, but for now... Let's make everyones life easier :)